### PR TITLE
Add possibility to request CSV for metrics

### DIFF
--- a/src/analytics.js
+++ b/src/analytics.js
@@ -37,6 +37,13 @@ Itunes.prototype.executeRequest = function(task, callback) {
 
   const requestBody = query.assembleBody();
   const uri = url.parse(query.apiURL + query.endpoint);
+
+  if(requestBody.csv) {
+    var isCSVRequest = true
+    delete requestBody.csv
+    var params = new URLSearchParams({data: JSON.stringify(requestBody)}).toString()
+  }
+
   const config = {
     uri: uri,
     headers: this.getHeaders(),
@@ -44,6 +51,11 @@ Itunes.prototype.executeRequest = function(task, callback) {
     json: requestBody,
     resolveWithFullResponse: true
   };
+
+  if(isCSVRequest) {
+    delete config.json
+    config['form'] = params
+  }
 
   request.post(config).then(response => {
     completed(null, response.body)

--- a/src/query.js
+++ b/src/query.js
@@ -295,6 +295,11 @@ var Query = function(appId, config) {
 Query.prototype.metrics = function() {
   this.endpoint = '/data/time-series';
 
+  if(this.config['csv']) {
+    console.log("Metrics called with csv. Experimental.")
+    this.endpoint = `${this.endpoint}-csv`
+  }
+
   var keys = ['limit', 'dimension'];
   for (var i = 0; i < keys.length; ++i) {
     var key = keys[i];


### PR DESCRIPTION
The other end requested me to provide data in CSV format instead of JSON.

We could simply do a client-side conversion from JSON to CSV but the App Store Connect website offers a CSV option.

It's not just the endpoint-URL tho - App Store Connect expects the CSV request to be query-encoded as formData and finding that out took me way more time than I am willing to publicly admit but I thought I should share.

Code-wise it gets a bit awkward due `form` being used instead of `json` but the "json-first, then adapt to csv if needed" approach is probably ok I guess.


**Usage:**

```
var query = AnalyticsQuery.metrics(APPID, {
        measures: type,
        dimension: itc.dimension.sourceType,
        ...
        csv: true // <----- here
    })
```

Alternative would be to pass as a new parameter and changing the constructor for that but I really don't think this is needed.